### PR TITLE
Dataline changes

### DIFF
--- a/arduino/TSL237_32u4/TSL237_32u4.ino
+++ b/arduino/TSL237_32u4/TSL237_32u4.ino
@@ -67,7 +67,7 @@ void loop() //loop is the other special function of arduinos; it repeats indefin
     t = cnt; //because interrupt is incredibly fast, t stores the count right when the reading is taken
     hz = round((t - oldcnt)*1000/(T-Tlast)); //takes photon counts and puts them in Hz (#/s)
     oldcnt = t; //remembers last count to calculate Hz next loop
-    message = String(volt)+","+String(hz)+","+String(sensors.getTempCByIndex(0))+","+
+    message = String(sensors.getTempCByIndex(0))+";"+String(hz)+";"+String(volt)+";"+
               String(TSLserialNR);
     Serial.println(message); //assembles message and sends it to the pi
     Tlast = T;


### PR DESCRIPTION
To match the data lines as described in the Community Standard Skyglow Data Format [here](https://drive.google.com/drive/u/2/folders/1Rs0KXmApVXYrfpiouh0anjhowbmELNe0), I made some changes to both the feather and PI programs. I think it makes the most sense to have the lines pre-formatted as closely as possible to the correct format so that sending the data off is as easy as truncating the last two or three columns and putting on a header. Otherwise, helper scripts need to be made to reconfigure the data, which I think is just going to add unneeded complexity. I'm not sure what effect this has on the mapping or plotting programs, but I imagine fixing them should be as easy as telling them to look in a different column for their data.

My question is does this mess up the data point averaging that was added to the PI program, and if so, what needs to be changed to support the new format?